### PR TITLE
implement add & remove methods + fix bugs

### DIFF
--- a/myArrayList.java
+++ b/myArrayList.java
@@ -1,29 +1,37 @@
+import java.util.ArrayList;
 
+public class myArrayList extends ArrayList<Fraction>
+{
+    public myArrayList() {
+        ensureCapacity(50);
+    }
 
-    import java.util.ArrayList;
-  public class myArrayList extends ArrayList<Fraction> {
+    public Fraction remove(int index) {
+        if (index < 0 || index >= size()) {
+            throw new IndexOutOfBoundsException("Index is out of bounds.");
+        }
 
+        return super.remove(index);
+    }
 
-      public myArrayList() {
-          ensureCapacity(50);
-      }
-      public Fraction remove(int index) {
-          if (index < 0 || index >= size()) {
-              throw new IndexOutOfBoundsException("Index is out of bounds.");
-          }
+    public void add(int index, Fraction input) {
+        if (index < 0 || index > size()) {
+            throw new IndexOutOfBoundsException("Index is out of bounds");
+        }
+        ensureCapacity(size() + 1);
+        super.add(index, input);
+    }
 
-          return super.remove(index);
-      }
+    public int indexOf(final Fraction input) {
+        return super.indexOf(input);
+    }
 
-      public void add(int index, Fraction input) {
-          if (index < 0 || index > size()) {
-              throw new IndexOutOfBoundsException("Index is out of bounds");
-          }
-          ensureCapacity(size() + 1);
-          super.add(index, input);
-      }
-      public int indexOf(Fraction input) {
-          return super.indexOf(input);
-      }
-  }
-
+    /**
+     * Expose this value, so it can be used to prevent possible desyncs from {@link myListIterator}.
+     * @return {@link ArrayList#modCount}.
+     *
+     * @since 1 October 2023
+     * @author Julian Edwards
+     */
+    int getModCount() { return modCount; }
+}

--- a/myListIterator.java
+++ b/myListIterator.java
@@ -1,24 +1,22 @@
+import java.util.Arrays;
+import java.util.ConcurrentModificationException;
 import java.util.ListIterator;
+import java.util.NoSuchElementException;
 
 public class myListIterator implements ListIterator<Fraction>
 {
-    // fields copied from ArrayList's implementation of ListIterator
     final myArrayList owner;
     int cursor;       // index of next element to return
-    int lastRet = -1; // index of last element returned; -1 if no such
-    int modCount;
-    int expectedModCount;
+    int lastRet = -1; // index of last element returned; -1 if none
+    int expectedModCount; // used to prevent a desync between this iterator and its owner
 
-    // ArrayList has a field called modCount, pass that in here.
-    myListIterator(myArrayList ownerIn, int modCountIn) {
+    myListIterator(final myArrayList ownerIn) {
         owner = ownerIn;
-        modCount = modCountIn;
-        expectedModCount = modCountIn;
+        expectedModCount = owner.getModCount();
     }
 
-    // ArrayList has a field called modCount, pass that in here.
-    myListIterator(myArrayList ownerIn, int modCountIn, int startIndexIn) {
-        this(ownerIn, modCountIn);
+    myListIterator(final myArrayList ownerIn, int startIndexIn) {
+        this(ownerIn);
         cursor = startIndexIn;
     }
 
@@ -125,10 +123,23 @@ public class myListIterator implements ListIterator<Fraction>
      *                                       {@code previous} have been called, or {@code remove} or
      *                                       {@code add} have been called after the last call to
      *                                       {@code next} or {@code previous}
+     *
+     * @since 1 October 2023
+     * @author Julian Edwards
      */
     @Override
     public void remove() {
+        if(lastRet < 0) throw new IllegalStateException();
+        else if(expectedModCount != owner.getModCount()) throw new ConcurrentModificationException();
 
+        try {
+            owner.remove(lastRet);
+            cursor = lastRet;
+            lastRet = -1;
+            expectedModCount = owner.getModCount();
+        }
+
+        catch(final IndexOutOfBoundsException e) { throw new ConcurrentModificationException(); }
     }
 
     /**
@@ -154,7 +165,7 @@ public class myListIterator implements ListIterator<Fraction>
      * @author Julian Edwards
      */
     @Override
-    public void set(Fraction fraction) {
+    public void set(final Fraction fraction) {
         throw new UnsupportedOperationException("Not used by the Lab2 assignment.");
     }
 
@@ -177,10 +188,20 @@ public class myListIterator implements ListIterator<Fraction>
      *                                       prevents it from being added to this list
      * @throws IllegalArgumentException      if some aspect of this element
      *                                       prevents it from being added to this list
+     *
+     * @since 1 October 2023
+     * @author Julian Edwards
      */
     @Override
-    public void add(Fraction fraction) {
+    public void add(final Fraction fraction) {
+        if(expectedModCount != owner.getModCount()) throw new ConcurrentModificationException();
+        try {
+            owner.add(cursor++, fraction);
+            lastRet = -1;
+            expectedModCount = owner.getModCount();
+        }
 
+        catch(final IndexOutOfBoundsException e) { throw new ConcurrentModificationException(); }
     }
 
     /**
@@ -202,11 +223,22 @@ public class myListIterator implements ListIterator<Fraction>
      *                                       prevents it from being added to this list
      * @throws IllegalArgumentException      if some aspect of the elements
      *                                       prevent them from being added to this list
-     * @since 25 September 2023
+     * @since 1 October 2023
      * @author Julian Edwards
      */
-    public void addAll(Fraction[] fractions) {
-        for(final Fraction fraction : fractions) add(fraction);
+    public void addAll(final Fraction[] fractions) {
+        if(fractions.length != 0) {
+            if(expectedModCount != owner.getModCount()) throw new ConcurrentModificationException();
+            try {
+                // it should be noted that Arrays::asList does not return a standard ArrayList, the one used here is an array wrapper
+                owner.addAll(cursor, Arrays.asList(fractions));
+                cursor += fractions.length;
+                lastRet = -1;
+                expectedModCount = owner.getModCount();
+            }
+
+            catch(final IndexOutOfBoundsException e) { throw new ConcurrentModificationException(); }
+        }
     }
 
     /**
@@ -222,17 +254,19 @@ public class myListIterator implements ListIterator<Fraction>
      *                                       {@code previous} have been called, or {@code remove} or
      *                                       {@code add} have been called after the last call to
      *                                       {@code next} or {@code previous}
-     * @since 25 September 2023
+     * @since 1 October 2023
      * @author Julian Edwards
      */
     public void removeAllNext() {
-        if(hasNext()) next(); // set cursor to next value, so the built-in remove method can be used.
-        else return; // no elements after current cursor, method cannot be called.
-        while(hasNext()) {  // remove all elements after the selected one.
-            next();
-            remove();
-        }
+        if(lastRet < 0) throw new IllegalStateException();
+        else if(expectedModCount != owner.getModCount()) throw new ConcurrentModificationException();
 
-        previous(); // set cursor back to the starting value (prior to this method being called).
+        if(lastRet >= owner.size() - 1) return; // no elements to be removed
+        lastRet++; // remove all elements after the selected one
+
+        while(lastRet < owner.size()) owner.remove(lastRet);
+        cursor = lastRet - 1;
+        lastRet = -1;
+        expectedModCount = owner.getModCount();
     }
 }


### PR DESCRIPTION
myArayList:
- neater whitespace
- add a getModCount method that's used as an accessor by myListIterator myListIterator:
- implement add & remove methods (not necessary for the assignment, but at first I thought I was gonna use them for addAll & removeAllNext, turns out this wasn't the case but I see no point in removing the logic now...)
- some small optimizations for addAll & removeAllNext
- remove myListIterator local modCount field (and replace it with an accessor to the myArrayList's modCount field)